### PR TITLE
Add immersive A-Frame experience playground

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,146 @@
+const experiences = [
+  {
+    id: "seaside",
+    label: "Seaside Photo",
+    type: "photo",
+    asset: "#asset-seaside",
+    description: "Golden hour on the Pacific coastline."
+  },
+  {
+    id: "mountain",
+    label: "Desert Photo",
+    type: "photo",
+    asset: "#asset-mountain",
+    description: "Clouds rolling over a red rock desert vista."
+  },
+  {
+    id: "city",
+    label: "Tokyo Night Video",
+    type: "video",
+    asset: "#asset-city",
+    description: "Night drive through Shinjuku's neon streets."
+  },
+  {
+    id: "ocean",
+    label: "Ocean Race Video",
+    type: "video",
+    asset: "#asset-ocean",
+    description: "Sail the waves in an offshore race."
+  }
+];
+
+const photoSphere = document.getElementById("photoSphere");
+const videoSphere = document.getElementById("videoSphere");
+const buttonContainer = document.getElementById("buttonContainer");
+const infoText = document.getElementById("infoText");
+
+const videoElements = experiences
+  .filter((exp) => exp.type === "video")
+  .map((exp) => document.querySelector(exp.asset))
+  .filter(Boolean);
+
+const buttonMap = new Map();
+
+function buildButtons() {
+  const spacing = 0.32;
+  const startY = ((experiences.length - 1) * spacing) / 2;
+
+  experiences.forEach((exp, index) => {
+    const button = document.createElement("a-entity");
+    button.setAttribute("class", "experience-button clickable");
+    button.setAttribute(
+      "geometry",
+      "primitive: plane; width: 1.4; height: 0.26;"
+    );
+    button.setAttribute(
+      "material",
+      "color: #1b6ef3; opacity: 0.92; shader: flat;"
+    );
+    button.setAttribute("position", `0 ${startY - index * spacing} 0`);
+
+    const label = document.createElement("a-text");
+    label.setAttribute("value", exp.label);
+    label.setAttribute("align", "center");
+    label.setAttribute("width", "1.3");
+    label.setAttribute("color", "#ffffff");
+    label.setAttribute("shader", "msdf");
+    label.setAttribute(
+      "font",
+      "https://cdn.aframe.io/fonts/Roboto-msdf.json"
+    );
+    label.setAttribute("position", "0 0 0.01");
+
+    button.appendChild(label);
+
+    button.addEventListener("mouseenter", () => {
+      if (button.getAttribute("data-active") === "true") return;
+      button.setAttribute(
+        "material",
+        "color: #3fa7ff; opacity: 1; shader: flat;"
+      );
+    });
+
+    button.addEventListener("mouseleave", () => {
+      if (button.getAttribute("data-active") === "true") return;
+      button.setAttribute(
+        "material",
+        "color: #1b6ef3; opacity: 0.92; shader: flat;"
+      );
+    });
+
+    button.addEventListener("click", () => activateExperience(exp));
+
+    buttonContainer.appendChild(button);
+    buttonMap.set(exp.id, button);
+  });
+}
+
+function setButtonState(activeId) {
+  buttonMap.forEach((button, id) => {
+    const isActive = id === activeId;
+    button.setAttribute("data-active", isActive);
+    button.setAttribute(
+      "material",
+      isActive
+        ? "color: #34d399; opacity: 1; shader: flat;"
+        : "color: #1b6ef3; opacity: 0.92; shader: flat;"
+    );
+  });
+}
+
+function activateExperience(exp) {
+  setButtonState(exp.id);
+  infoText.setAttribute("value", exp.description);
+
+  if (exp.type === "photo") {
+    videoSphere.setAttribute("visible", false);
+    pauseAllVideos();
+    photoSphere.setAttribute("src", exp.asset);
+    photoSphere.setAttribute("visible", true);
+  } else if (exp.type === "video") {
+    const videoEl = document.querySelector(exp.asset);
+    if (!videoEl) return;
+    photoSphere.setAttribute("visible", false);
+    videoSphere.setAttribute("src", exp.asset);
+    videoSphere.setAttribute("visible", true);
+    pauseAllVideos(videoEl);
+    const playPromise = videoEl.play();
+    if (playPromise && typeof playPromise.catch === "function") {
+      playPromise.catch(() => {
+        // Autoplay might be blocked until the user interacts in-headset.
+      });
+    }
+  }
+}
+
+function pauseAllVideos(exempt) {
+  videoElements.forEach((video) => {
+    if (video === exempt) return;
+    if (!video) return;
+    video.pause();
+    video.currentTime = 0;
+  });
+}
+
+buildButtons();
+activateExperience(experiences[0]);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Immersive Experience Playground</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
+  </head>
+  <body>
+    <header class="page-header">
+      <h1>Immersive Experience Playground</h1>
+      <p>
+        Launch a 360° scene and click the VR button to step inside using a Meta
+        Quest 3/3S or a mobile browser. Aim with your controllers or pointer to
+        press the buttons floating in front of you.
+      </p>
+    </header>
+
+    <a-scene
+      background="color: #000"
+      renderer="antialias: true"
+      webxr="optionalFeatures: local-floor, bounded-floor"
+      vr-mode-ui="enabled: true"
+    >
+      <a-assets timeout="30000">
+        <img
+          id="asset-seaside"
+          crossorigin="anonymous"
+          src="https://cdn.aframe.io/360-image-gallery-boilerplate/img/sechelt.jpg"
+        />
+        <img
+          id="asset-mountain"
+          crossorigin="anonymous"
+          src="https://cdn.aframe.io/360-image-gallery-boilerplate/img/yavapai.jpg"
+        />
+        <video
+          id="asset-city"
+          loop
+          muted
+          playsinline
+          crossorigin="anonymous"
+          preload="auto"
+          src="https://cdn.aframe.io/videos/360-video/japan360.mp4"
+        ></video>
+        <video
+          id="asset-ocean"
+          loop
+          muted
+          playsinline
+          crossorigin="anonymous"
+          preload="auto"
+          src="https://cdn.aframe.io/videos/360-video/race360.mp4"
+        ></video>
+      </a-assets>
+
+      <a-entity id="rig" position="0 0 0">
+        <a-entity
+          id="player"
+          camera
+          look-controls="magicWindowTrackingEnabled: true"
+          wasd-controls="enabled: false"
+          position="0 1.6 0"
+        >
+          <a-entity
+            id="mouseCursor"
+            cursor="rayOrigin: mouse"
+            raycaster="objects: .clickable"
+            position="0 0 -1"
+            geometry="primitive: ring; radiusInner: 0.005; radiusOuter: 0.008"
+            material="color: #fff; shader: flat; opacity: 0.9"
+          ></a-entity>
+        </a-entity>
+
+        <a-entity
+          laser-controls="hand: left"
+          raycaster="objects: .clickable"
+        ></a-entity>
+        <a-entity
+          laser-controls="hand: right"
+          raycaster="objects: .clickable"
+        ></a-entity>
+      </a-entity>
+
+      <a-sky id="photoSphere" radius="100" src="#asset-seaside"></a-sky>
+      <a-videosphere
+        id="videoSphere"
+        radius="100"
+        src="#asset-city"
+        visible="false"
+      ></a-videosphere>
+
+      <a-entity id="menu" position="0 1.5 -2">
+        <a-plane
+          width="1.8"
+          height="1.2"
+          color="#101820"
+          opacity="0.85"
+          material="shader: flat; side: double"
+          class="menu-surface"
+        ></a-plane>
+        <a-text
+          value="Choose an experience"
+          position="0 0.45 0.01"
+          width="1.6"
+          align="center"
+          color="#f4f4f4"
+          shader="msdf"
+          font="https://cdn.aframe.io/fonts/Roboto-msdf.json"
+        ></a-text>
+        <a-entity id="buttonContainer" position="0 -0.05 0.01"></a-entity>
+      </a-entity>
+
+      <a-entity id="infoLabel" position="0 0.5 -1.7">
+        <a-text
+          id="infoText"
+          value="Seaside Photo"
+          width="2"
+          align="center"
+          color="#f4f4f4"
+          shader="msdf"
+          font="https://cdn.aframe.io/fonts/Roboto-msdf.json"
+        ></a-text>
+      </a-entity>
+    </a-scene>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,48 @@
+:root {
+  color-scheme: dark;
+  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #050505;
+  color: #f4f4f4;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.page-header {
+  padding: 1.5rem clamp(1rem, 5vw, 3rem);
+  max-width: 960px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.page-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  font-weight: 700;
+}
+
+.page-header p {
+  margin: 0 auto;
+  max-width: 48ch;
+  font-size: 1rem;
+}
+
+a-scene {
+  width: 100%;
+  flex: 1 1 auto;
+}
+
+@media (max-width: 640px) {
+  .page-header {
+    padding-bottom: 0.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- create an A-Frame powered 360° playground scene that works on headsets or mobile
- add floating VR-friendly buttons to swap between image and video experiences
- provide baseline styling and copy to explain how to launch the immersive mode

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cee8cd27f88331ade26f74cdd2d813